### PR TITLE
A user hint and confirmation

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -46,6 +46,14 @@ $unused_terms               = WPSweep::get_instance()->count( 'unused_terms' );
 
 $transient_options          = WPSweep::get_instance()->count( 'transient_options' );
 ?>
+<style type="text/css">
+.table-sweep thead th {
+	width: 12%;
+}
+.table-sweep thead th.col-sweep-details {
+	width: 64%;
+}
+</style>
 <div class="wrap">
 	<h2><?php _e( 'WP-Sweep', 'wp-sweep' ); ?></h2>
 	<?php if( ! empty( $message ) ): ?>
@@ -58,13 +66,13 @@ $transient_options          = WPSweep::get_instance()->count( 'transient_options
 	</div>
 	<h3><?php _e( 'Post Sweep', 'wp-sweep' ); ?></h3>
 	<p><?php printf( __( 'There are a total of <strong class="attention">%s Posts</strong> and <strong class="attention">%s Post Meta</strong>.', 'wp-sweep' ), number_format_i18n( $total_posts ), number_format_i18n( $total_postmeta ) ); ?></p>
-	<table class="widefat">
+	<table class="widefat table-sweep">
 		<thead>
 			<tr>
-				<th style="width: 64%;"><?php _e( 'Details', 'wp-sweep' ); ?></th>
-				<th style="width: 12%;"><?php _e( 'Count', 'wp-sweep' ); ?></th>
-				<th style="width: 12%;"><?php _e( '% Of', 'wp-sweep' ); ?></th>
-				<th style="width: 12%;"><?php _e( 'Action', 'wp-sweep' ); ?></th>
+				<th class="col-sweep-details"><?php _e( 'Details', 'wp-sweep' ); ?></th>
+				<th class="col-sweep-count"><?php _e( 'Count', 'wp-sweep' ); ?></th>
+				<th class="col-sweep-percent"><?php _e( '% Of', 'wp-sweep' ); ?></th>
+				<th class="col-sweep-action"><?php _e( 'Action', 'wp-sweep' ); ?></th>
 			</tr>
 		</thead>
 		<tbody>
@@ -163,13 +171,13 @@ $transient_options          = WPSweep::get_instance()->count( 'transient_options
 	<p>&nbsp;</p>
 	<h3><?php _e( 'Comment Sweep', 'wp-sweep' ); ?></h3>
 	<p><?php printf( __( 'There are a total of <strong class="attention">%s Comments</strong> and <strong class="attention">%s Comment Meta</strong>.', 'wp-sweep' ), number_format_i18n( $total_comments ), number_format_i18n( $total_commentmeta ) ); ?></p>
-	<table class="widefat">
+	<table class="widefat table-sweep">
 		<thead>
 			<tr>
-				<th style="width: 64%;"><?php _e( 'Details', 'wp-sweep' ); ?></th>
-				<th style="width: 12%;"><?php _e( 'Count', 'wp-sweep' ); ?></th>
-				<th style="width: 12%;"><?php _e( '% Of', 'wp-sweep' ); ?></th>
-				<th style="width: 12%;"><?php _e( 'Action', 'wp-sweep' ); ?></th>
+				<th class="col-sweep-details"><?php _e( 'Details', 'wp-sweep' ); ?></th>
+				<th class="col-sweep-count"><?php _e( 'Count', 'wp-sweep' ); ?></th>
+				<th class="col-sweep-percent"><?php _e( '% Of', 'wp-sweep' ); ?></th>
+				<th class="col-sweep-action"><?php _e( 'Action', 'wp-sweep' ); ?></th>
 			</tr>
 		</thead>
 		<tbody>
@@ -268,13 +276,13 @@ $transient_options          = WPSweep::get_instance()->count( 'transient_options
 	<p>&nbsp;</p>
 	<h3><?php _e( 'User Sweep', 'wp-sweep' ); ?></h3>
 	<p><?php printf( __( 'There are a total of <strong class="attention">%s Users</strong> and <strong class="attention">%s User Meta</strong>.', 'wp-sweep' ), number_format_i18n( $total_users ), number_format_i18n( $total_usermeta ) ); ?></p>
-	<table class="widefat">
+	<table class="widefat table-sweep">
 		<thead>
 			<tr>
-				<th style="width: 64%;"><?php _e( 'Details', 'wp-sweep' ); ?></th>
-				<th style="width: 12%;"><?php _e( 'Count', 'wp-sweep' ); ?></th>
-				<th style="width: 12%;"><?php _e( '% Of', 'wp-sweep' ); ?></th>
-				<th style="width: 12%;"><?php _e( 'Action', 'wp-sweep' ); ?></th>
+				<th class="col-sweep-details"><?php _e( 'Details', 'wp-sweep' ); ?></th>
+				<th class="col-sweep-count"><?php _e( 'Count', 'wp-sweep' ); ?></th>
+				<th class="col-sweep-percent"><?php _e( '% Of', 'wp-sweep' ); ?></th>
+				<th class="col-sweep-action"><?php _e( 'Action', 'wp-sweep' ); ?></th>
 			</tr>
 		</thead>
 		<tbody>
@@ -319,13 +327,13 @@ $transient_options          = WPSweep::get_instance()->count( 'transient_options
 	<p>&nbsp;</p>
 	<h3><?php _e( 'Term Sweep', 'wp-sweep' ); ?></h3>
 	<p><?php printf( __( 'There are a total of <strong class="attention">%s Terms</strong>, <strong class="attention">%s Term Taxonomy</strong> and <strong class="attention">%s Term Relationships</strong>.', 'wp-sweep' ), number_format_i18n( $total_terms ), number_format_i18n( $total_term_taxonomy ), number_format_i18n( $total_term_relationships ) ); ?></p>
-	<table class="widefat">
+	<table class="widefat table-sweep">
 		<thead>
 			<tr>
-				<th style="width: 64%;"><?php _e( 'Details', 'wp-sweep' ); ?></th>
-				<th style="width: 12%;"><?php _e( 'Count', 'wp-sweep' ); ?></th>
-				<th style="width: 12%;"><?php _e( '% Of', 'wp-sweep' ); ?></th>
-				<th style="width: 12%;"><?php _e( 'Action', 'wp-sweep' ); ?></th>
+				<th class="col-sweep-details"><?php _e( 'Details', 'wp-sweep' ); ?></th>
+				<th class="col-sweep-count"><?php _e( 'Count', 'wp-sweep' ); ?></th>
+				<th class="col-sweep-percent"><?php _e( '% Of', 'wp-sweep' ); ?></th>
+				<th class="col-sweep-action"><?php _e( 'Action', 'wp-sweep' ); ?></th>
 			</tr>
 		</thead>
 		<tbody>
@@ -371,13 +379,13 @@ $transient_options          = WPSweep::get_instance()->count( 'transient_options
 	<p>&nbsp;</p>
 	<h3><?php _e( 'Option Sweep', 'wp-sweep' ); ?></h3>
 	<p><?php printf( __( 'There are a total of <strong class="attention">%s Options</strong>.', 'wp-sweep' ), number_format_i18n( $total_options ) ); ?></p>
-	<table class="widefat">
+	<table class="widefat table-sweep">
 		<thead>
 			<tr>
-				<th style="width: 64%;"><?php _e( 'Details', 'wp-sweep' ); ?></th>
-				<th style="width: 12%;"><?php _e( 'Count', 'wp-sweep' ); ?></th>
-				<th style="width: 12%;"><?php _e( '% Of', 'wp-sweep' ); ?></th>
-				<th style="width: 12%;"><?php _e( 'Action', 'wp-sweep' ); ?></th>
+				<th class="col-sweep-details"><?php _e( 'Details', 'wp-sweep' ); ?></th>
+				<th class="col-sweep-count"><?php _e( 'Count', 'wp-sweep' ); ?></th>
+				<th class="col-sweep-percent"><?php _e( '% Of', 'wp-sweep' ); ?></th>
+				<th class="col-sweep-action"><?php _e( 'Action', 'wp-sweep' ); ?></th>
 			</tr>
 		</thead>
 		<tbody>

--- a/admin.php
+++ b/admin.php
@@ -80,7 +80,7 @@ $transient_options          = WPSweep::get_instance()->count( 'transient_options
 				</td>
 				<td>
 					<?php if( ! empty( $revisions ) ): ?>
-						<a href="<?php echo wp_nonce_url( $current_page . '&sweep=revisions', 'wp_sweep_revisions' ); ?>" class="button button-primary"><?php _e( 'Sweep', 'wp-sweep' ); ?></a>
+						<a href="<?php echo wp_nonce_url( $current_page . '&sweep=revisions', 'wp_sweep_revisions' ); ?>" class="button button-primary" data-sweeping="<?php _e( 'Sweeping...', 'wp-sweep' ); ?>"><?php _e( 'Sweep', 'wp-sweep' ); ?></a>
 					<?php else: ?>
 						<?php _e( 'N/A', 'wp-sweep' ); ?>
 					<?php endif; ?>
@@ -98,7 +98,7 @@ $transient_options          = WPSweep::get_instance()->count( 'transient_options
 				</td>
 				<td>
 					<?php if( ! empty( $auto_drafts ) ): ?>
-						<a href="<?php echo wp_nonce_url( $current_page . '&sweep=auto_drafts', 'wp_sweep_auto_drafts' ); ?>" class="button button-primary"><?php _e( 'Sweep', 'wp-sweep' ); ?></a>
+						<a href="<?php echo wp_nonce_url( $current_page . '&sweep=auto_drafts', 'wp_sweep_auto_drafts' ); ?>" class="button button-primary" data-sweeping="<?php _e( 'Sweeping...', 'wp-sweep' ); ?>"><?php _e( 'Sweep', 'wp-sweep' ); ?></a>
 					<?php else: ?>
 						<?php _e( 'N/A', 'wp-sweep' ); ?>
 					<?php endif; ?>
@@ -116,7 +116,7 @@ $transient_options          = WPSweep::get_instance()->count( 'transient_options
 				</td>
 				<td>
 					<?php if( ! empty( $deleted_posts ) ): ?>
-						<a href="<?php echo wp_nonce_url( $current_page . '&sweep=deleted_posts', 'wp_sweep_deleted_posts' ); ?>" class="button button-primary"><?php _e( 'Sweep', 'wp-sweep' ); ?></a>
+						<a href="<?php echo wp_nonce_url( $current_page . '&sweep=deleted_posts', 'wp_sweep_deleted_posts' ); ?>" class="button button-primary" data-sweeping="<?php _e( 'Sweeping...', 'wp-sweep' ); ?>"><?php _e( 'Sweep', 'wp-sweep' ); ?></a>
 					<?php else: ?>
 						<?php _e( 'N/A', 'wp-sweep' ); ?>
 					<?php endif; ?>
@@ -134,7 +134,7 @@ $transient_options          = WPSweep::get_instance()->count( 'transient_options
 				</td>
 				<td>
 					<?php if( ! empty( $orphan_postmeta ) ): ?>
-						<a href="<?php echo wp_nonce_url( $current_page . '&sweep=orphan_postmeta', 'wp_sweep_orphan_postmeta' ); ?>" class="button button-primary"><?php _e( 'Sweep', 'wp-sweep' ); ?></a>
+						<a href="<?php echo wp_nonce_url( $current_page . '&sweep=orphan_postmeta', 'wp_sweep_orphan_postmeta' ); ?>" class="button button-primary" data-sweeping="<?php _e( 'Sweeping...', 'wp-sweep' ); ?>"><?php _e( 'Sweep', 'wp-sweep' ); ?></a>
 					<?php else: ?>
 						<?php _e( 'N/A', 'wp-sweep' ); ?>
 					<?php endif; ?>
@@ -152,7 +152,7 @@ $transient_options          = WPSweep::get_instance()->count( 'transient_options
 				</td>
 				<td>
 					<?php if( ! empty( $duplicated_postmeta ) ): ?>
-						<a href="<?php echo wp_nonce_url( $current_page . '&sweep=duplicated_postmeta', 'wp_sweep_duplicated_postmeta' ); ?>" class="button button-primary"><?php _e( 'Sweep', 'wp-sweep' ); ?></a>
+						<a href="<?php echo wp_nonce_url( $current_page . '&sweep=duplicated_postmeta', 'wp_sweep_duplicated_postmeta' ); ?>" class="button button-primary" data-sweeping="<?php _e( 'Sweeping...', 'wp-sweep' ); ?>"><?php _e( 'Sweep', 'wp-sweep' ); ?></a>
 					<?php else: ?>
 						<?php _e( 'N/A', 'wp-sweep' ); ?>
 					<?php endif; ?>
@@ -185,7 +185,7 @@ $transient_options          = WPSweep::get_instance()->count( 'transient_options
 				</td>
 				<td>
 					<?php if( ! empty( $unapproved_comments ) ): ?>
-						<a href="<?php echo wp_nonce_url( $current_page . '&sweep=unapproved_comments', 'wp_sweep_unapproved_comments' ); ?>" class="button button-primary"><?php _e( 'Sweep', 'wp-sweep' ); ?></a>
+						<a href="<?php echo wp_nonce_url( $current_page . '&sweep=unapproved_comments', 'wp_sweep_unapproved_comments' ); ?>" class="button button-primary" data-sweeping="<?php _e( 'Sweeping...', 'wp-sweep' ); ?>"><?php _e( 'Sweep', 'wp-sweep' ); ?></a>
 					<?php else: ?>
 						<?php _e( 'N/A', 'wp-sweep' ); ?>
 					<?php endif; ?>
@@ -203,7 +203,7 @@ $transient_options          = WPSweep::get_instance()->count( 'transient_options
 				</td>
 				<td>
 					<?php if( ! empty( $spam_comments ) ): ?>
-						<a href="<?php echo wp_nonce_url( $current_page . '&sweep=spam_comments', 'wp_sweep_spam_comments' ); ?>" class="button button-primary"><?php _e( 'Sweep', 'wp-sweep' ); ?></a>
+						<a href="<?php echo wp_nonce_url( $current_page . '&sweep=spam_comments', 'wp_sweep_spam_comments' ); ?>" class="button button-primary" data-sweeping="<?php _e( 'Sweeping...', 'wp-sweep' ); ?>"><?php _e( 'Sweep', 'wp-sweep' ); ?></a>
 					<?php else: ?>
 						<?php _e( 'N/A', 'wp-sweep' ); ?>
 					<?php endif; ?>
@@ -221,7 +221,7 @@ $transient_options          = WPSweep::get_instance()->count( 'transient_options
 				</td>
 				<td>
 					<?php if( ! empty( $deleted_comments ) ): ?>
-						<a href="<?php echo wp_nonce_url( $current_page . '&sweep=deleted_comments', 'wp_sweep_deleted_comments' ); ?>" class="button button-primary"><?php _e( 'Sweep', 'wp-sweep' ); ?></a>
+						<a href="<?php echo wp_nonce_url( $current_page . '&sweep=deleted_comments', 'wp_sweep_deleted_comments' ); ?>" class="button button-primary" data-sweeping="<?php _e( 'Sweeping...', 'wp-sweep' ); ?>"><?php _e( 'Sweep', 'wp-sweep' ); ?></a>
 					<?php else: ?>
 						<?php _e( 'N/A', 'wp-sweep' ); ?>
 					<?php endif; ?>
@@ -239,7 +239,7 @@ $transient_options          = WPSweep::get_instance()->count( 'transient_options
 				</td>
 				<td>
 					<?php if( ! empty( $orphan_commentmeta ) ): ?>
-						<a href="<?php echo wp_nonce_url( $current_page . '&sweep=orphan_commentmeta', 'wp_sweep_orphan_commentmeta' ); ?>" class="button button-primary"><?php _e( 'Sweep', 'wp-sweep' ); ?></a>
+						<a href="<?php echo wp_nonce_url( $current_page . '&sweep=orphan_commentmeta', 'wp_sweep_orphan_commentmeta' ); ?>" class="button button-primary" data-sweeping="<?php _e( 'Sweeping...', 'wp-sweep' ); ?>"><?php _e( 'Sweep', 'wp-sweep' ); ?></a>
 					<?php else: ?>
 						<?php _e( 'N/A', 'wp-sweep' ); ?>
 					<?php endif; ?>
@@ -257,7 +257,7 @@ $transient_options          = WPSweep::get_instance()->count( 'transient_options
 				</td>
 				<td>
 					<?php if( ! empty( $duplicated_commentmeta ) ): ?>
-						<a href="<?php echo wp_nonce_url( $current_page . '&sweep=duplicated_commentmeta', 'wp_sweep_duplicated_commentmeta' ); ?>" class="button button-primary"><?php _e( 'Sweep', 'wp-sweep' ); ?></a>
+						<a href="<?php echo wp_nonce_url( $current_page . '&sweep=duplicated_commentmeta', 'wp_sweep_duplicated_commentmeta' ); ?>" class="button button-primary" data-sweeping="<?php _e( 'Sweeping...', 'wp-sweep' ); ?>"><?php _e( 'Sweep', 'wp-sweep' ); ?></a>
 					<?php else: ?>
 						<?php _e( 'N/A', 'wp-sweep' ); ?>
 					<?php endif; ?>
@@ -290,7 +290,7 @@ $transient_options          = WPSweep::get_instance()->count( 'transient_options
 				</td>
 				<td>
 					<?php if( ! empty( $orphan_usermeta ) ): ?>
-						<a href="<?php echo wp_nonce_url( $current_page . '&sweep=orphan_usermeta', 'wp_sweep_orphan_usermeta' ); ?>" class="button button-primary"><?php _e( 'Sweep', 'wp-sweep' ); ?></a>
+						<a href="<?php echo wp_nonce_url( $current_page . '&sweep=orphan_usermeta', 'wp_sweep_orphan_usermeta' ); ?>" class="button button-primary" data-sweeping="<?php _e( 'Sweeping...', 'wp-sweep' ); ?>"><?php _e( 'Sweep', 'wp-sweep' ); ?></a>
 					<?php else: ?>
 						<?php _e( 'N/A', 'wp-sweep' ); ?>
 					<?php endif; ?>
@@ -308,7 +308,7 @@ $transient_options          = WPSweep::get_instance()->count( 'transient_options
 				</td>
 				<td>
 					<?php if( ! empty( $duplicated_usermeta ) ): ?>
-						<a href="<?php echo wp_nonce_url( $current_page . '&sweep=duplicated_usermeta', 'wp_sweep_duplicated_usermeta' ); ?>" class="button button-primary"><?php _e( 'Sweep', 'wp-sweep' ); ?></a>
+						<a href="<?php echo wp_nonce_url( $current_page . '&sweep=duplicated_usermeta', 'wp_sweep_duplicated_usermeta' ); ?>" class="button button-primary" data-sweeping="<?php _e( 'Sweeping...', 'wp-sweep' ); ?>"><?php _e( 'Sweep', 'wp-sweep' ); ?></a>
 					<?php else: ?>
 						<?php _e( 'N/A', 'wp-sweep' ); ?>
 					<?php endif; ?>
@@ -341,7 +341,7 @@ $transient_options          = WPSweep::get_instance()->count( 'transient_options
 				</td>
 				<td>
 					<?php if( ! empty( $orphan_term_relationships ) ): ?>
-						<a href="<?php echo wp_nonce_url( $current_page . '&sweep=orphan_term_relationships', 'wp_sweep_orphan_term_relationships' ); ?>" class="button button-primary"><?php _e( 'Sweep', 'wp-sweep' ); ?></a>
+						<a href="<?php echo wp_nonce_url( $current_page . '&sweep=orphan_term_relationships', 'wp_sweep_orphan_term_relationships' ); ?>" class="button button-primary" data-sweeping="<?php _e( 'Sweeping...', 'wp-sweep' ); ?>"><?php _e( 'Sweep', 'wp-sweep' ); ?></a>
 					<?php else: ?>
 						<?php _e( 'N/A', 'wp-sweep' ); ?>
 					<?php endif; ?>
@@ -360,7 +360,7 @@ $transient_options          = WPSweep::get_instance()->count( 'transient_options
 				</td>
 				<td>
 					<?php if( ! empty( $unused_terms ) ): ?>
-						<a href="<?php echo wp_nonce_url( $current_page . '&sweep=unused_terms', 'wp_sweep_unused_terms' ); ?>" class="button button-primary"><?php _e( 'Sweep', 'wp-sweep' ); ?></a>
+						<a href="<?php echo wp_nonce_url( $current_page . '&sweep=unused_terms', 'wp_sweep_unused_terms' ); ?>" class="button button-primary" data-sweeping="<?php _e( 'Sweeping...', 'wp-sweep' ); ?>"><?php _e( 'Sweep', 'wp-sweep' ); ?></a>
 					<?php else: ?>
 						<?php _e( 'N/A', 'wp-sweep' ); ?>
 					<?php endif; ?>
@@ -393,7 +393,7 @@ $transient_options          = WPSweep::get_instance()->count( 'transient_options
 				</td>
 				<td>
 					<?php if( ! empty( $transient_options ) ): ?>
-						<a href="<?php echo wp_nonce_url( $current_page . '&sweep=transient_options', 'wp_sweep_transient_options' ); ?>" class="button button-primary"><?php _e( 'Sweep', 'wp-sweep' ); ?></a>
+						<a href="<?php echo wp_nonce_url( $current_page . '&sweep=transient_options', 'wp_sweep_transient_options' ); ?>" class="button button-primary" data-sweeping="<?php _e( 'Sweeping...', 'wp-sweep' ); ?>"><?php _e( 'Sweep', 'wp-sweep' ); ?></a>
 					<?php else: ?>
 						<?php _e( 'N/A', 'wp-sweep' ); ?>
 					<?php endif; ?>

--- a/wp-sweep.js
+++ b/wp-sweep.js
@@ -22,7 +22,8 @@
 		 */
 		$(window).on('beforeunload', function (e) {
 			if (body.hasClass('sweep-active')) {
-				return wpSweep.closeWarning;
+				(e || window.event).returnValue = wpSweep.closeWarning; // Gecko and Trident
+				return wpSweep.closeWarning; // Gecko and WebKit
 			}
 		});
 

--- a/wp-sweep.js
+++ b/wp-sweep.js
@@ -1,25 +1,31 @@
-jQuery(document).ready(function ($) {
+(function ($) {
+	'use strict';
 
 	var body = $('body'),
 		btn = $('[data-sweeping]');
 
-	/*
-	Prevent multiple sweeps at once
-	 */
-	btn.on('click', function (event) {
-		event.preventDefault();
-		$(this).addClass('disabled').text($(this).attr('data-sweeping'));
-		body.addClass('sweep-active');
+	$(function () {
+
+		/*
+		Prevent multiple sweeps at once
+		 */
+		btn.on('click', function () {
+			$(this).addClass('disabled').text($(this).attr('data-sweeping'));
+			setTimeout(function () {
+				body.addClass('sweep-active');
+			}, 50);
+		});
+
+		/*
+		Page closing confirmation
+		https://developer.mozilla.org/en-US/docs/DOM/Mozilla_event_reference/beforeunload
+		 */
+		$(window).on('beforeunload', function (e) {
+			if (body.hasClass('sweep-active')) {
+				return wpSweep.closeWarning;
+			}
+		});
+
 	});
 
-	/*
-	Page closing confirmation
-	https://developer.mozilla.org/en-US/docs/DOM/Mozilla_event_reference/beforeunload
-	 */
-	$(window).on('beforeunload', function (e) {
-		if (body.hasClass('sweep-active')) {
-			return wpSweep.closeWarning;
-		}
-	});
-
-});
+})(jQuery);

--- a/wp-sweep.js
+++ b/wp-sweep.js
@@ -1,0 +1,25 @@
+jQuery(document).ready(function ($) {
+
+	var body = $('body'),
+		btn = $('[data-sweeping]');
+
+	/*
+	Prevent multiple sweeps at once
+	 */
+	btn.on('click', function (event) {
+		event.preventDefault();
+		$(this).addClass('disabled').text($(this).attr('data-sweeping'));
+		body.addClass('sweep-active');
+	});
+
+	/*
+	Page closing confirmation
+	https://developer.mozilla.org/en-US/docs/DOM/Mozilla_event_reference/beforeunload
+	 */
+	$(window).on('beforeunload', function (e) {
+		if (body.hasClass('sweep-active')) {
+			return wpSweep.closeWarning;
+		}
+	});
+
+});

--- a/wp-sweep.php
+++ b/wp-sweep.php
@@ -109,7 +109,7 @@ class WPSweep {
 		}
 
 		wp_enqueue_script( 'wp-sweep', trailingslashit( plugin_dir_url( __FILE__ ) ) . 'wp-sweep.js', array( 'jquery' ), WP_SWEEP_VERSION, true );
-		wp_localize_script( 'wp-sweep', 'wpSweep', array( 'closeWarning' => __( 'Sweeping is in progress. Are you sure to leave?', 'wp-sweep' ) ) );
+		wp_localize_script( 'wp-sweep', 'wpSweep', array( 'closeWarning' => __( 'Sweeping is in progress. If you leave now the process won\'t be completed.', 'wp-sweep' ) ) );
 
 		return true;
 

--- a/wp-sweep.php
+++ b/wp-sweep.php
@@ -90,6 +90,28 @@ class WPSweep {
 		// Actions
 		add_action( 'init', array( $this, 'init' ) );
 		add_action( 'admin_menu', array( $this, 'admin_menu' ) );
+		add_action( 'admin_print_scripts', array( $this, 'load_scripts' ) );
+	}
+
+	/**
+	 * Load the plugin script.
+	 *
+	 * @since  1.0.3
+	 * @access public
+	 * @return bool    Whether or not the script was enqueued
+	 */
+	public function load_scripts() {
+
+		$page = filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING );
+
+		if ( 'wp-sweep/admin.php' !== $page ) {
+			return false;
+		}
+
+		wp_enqueue_script( 'wp-sweep', trailingslashit( plugin_dir_url( __FILE__ ) ) . 'wp-sweep.js', array( 'jquery' ), WP_SWEEP_VERSION, true );
+
+		return true;
+
 	}
 
 	/**

--- a/wp-sweep.php
+++ b/wp-sweep.php
@@ -109,6 +109,7 @@ class WPSweep {
 		}
 
 		wp_enqueue_script( 'wp-sweep', trailingslashit( plugin_dir_url( __FILE__ ) ) . 'wp-sweep.js', array( 'jquery' ), WP_SWEEP_VERSION, true );
+		wp_localize_script( 'wp-sweep', 'wpSweep', array( 'closeWarning' => __( 'Sweeping is in progress. Are you sure to leave?', 'wp-sweep' ) ) );
 
 		return true;
 


### PR DESCRIPTION
Hi Lester!

Great little plugin. I'm switching all my sites from WP-Optimize to this :+1: 

The main goal of this fork is to provide useful bits of information to the user. I believe that the user should be aware of what's happening in the background. Now, when a user clicks "Sweep", it shows "Sweeping.." (you can edit the wording). If the user tries to close / refresh the page, he will be warned that the sweep action is in progress.

If you create a "Sweep All" button, you can re-use this. Simply add `data-sweeping="<?php _e( 'Sweeping...', 'wp-sweep' ); ?>"`.

Also, I made a small edit to the admin page itself. I think it's best to use the `<style>` tag instead of inline style attribute because it:

* provides a clear separation of markup from styling;
* produces cleaner HTML markup
* is more efficient with selectors to apply rules to multiple elements on a page improving management as well as making your page size smaller.

Lemme know what you think.