### PR TITLE
Changed menu page capability to 'manage_options'

### DIFF
--- a/wp-sweep.php
+++ b/wp-sweep.php
@@ -163,7 +163,7 @@ class WPSweep {
 	 * @return void
 	 */
 	public function admin_menu() {
-		add_management_page( __( 'Sweep', 'wp-sweep' ), __( 'Sweep', 'wp-sweep' ), 'activate_plugins', 'wp-sweep/admin.php' );
+		add_management_page( __( 'Sweep', 'wp-sweep' ), __( 'Sweep', 'wp-sweep' ), 'manage_options', 'wp-sweep/admin.php' );
 	}
 
 


### PR DESCRIPTION
Hello, Lester!

The current menu page capability of 'activate_plugins' causes problems for Admin Menu Editor on multisite installs because it's a capability reserved only for Super Admins. Changing it to 'manage_options' solves the conflict allowing Admin Menu Editor to escalate the privileges as required.