### PR TITLE
Change menu item name

### DIFF
--- a/wp-sweep.php
+++ b/wp-sweep.php
@@ -164,7 +164,7 @@ class WPSweep {
 	 * @return void
 	 */
 	public function admin_menu() {
-		add_management_page( __( 'Sweep', 'wp-sweep' ), __( 'Sweep', 'wp-sweep' ), 'manage_options', 'wp-sweep/admin.php' );
+		add_management_page( __( 'WP-Sweep', 'wp-sweep' ), __( 'WP-Sweep', 'wp-sweep' ), 'manage_options', 'wp-sweep/admin.php' );
 	}
 
 


### PR DESCRIPTION
If you translate WP-Sweep into different languages the menu item "sweep" will be translated like the "sweep" buttons in admin page. This can be problematic in some languages.
Changing this to the plugin name will be more clear for all users.