### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,16 @@
 language: php
 php:
+  - 7.2
+  - 7.1
   - 7.0
   - 5.6
   - 5.5
   - 5.4
+  - nightly
 
 matrix:
   allow_failures:
-    - php: 7.0
+    - php: nightly
 
 script:
   - find . "(" -name "*.php" ")" -exec php --syntax-check --file "{}" ";"


### PR DESCRIPTION
added php 7.1, 7.2 and 7.0 warnings

https://wordpress.org/about/stats/