### PR TITLE
Remove non-compatibility note for Asgaros Forum

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ WP-Sweep Available Items:
 * oembed_postmeta
 
 WP-Sweep is not compatible with the following plugins:
-* [Asgaros Forum](https://wordpress.org/plugins/asgaros-forum/)
 * [Custom Fonts](https://wordpress.org/plugins/custom-fonts/)
 * [Elementor Popup Builder](https://elementor.com/features/popup-builder/)
 * [MailPress](https://wordpress.org/plugins/mailpress/)


### PR DESCRIPTION
Hi @lesterchan ,

Since version 2.7 Asgaros Forum is fully compatible with WP-Sweep. Therefore, the non-compatibility note for Asgaros Forum can be removed from the README.md file.

Corresponding commit:
https://github.com/Asgaros/asgaros-forum/commit/a5256f719026749f4ff278cbb5073affdbd15405

Corresponding release:
https://github.com/Asgaros/asgaros-forum/releases/tag/v2.7.0

This version has already been published on the official WordPress.org plugin repository.