### PR TITLE
Add per-type meta key filters to protect metadata from accidental deletion

### DIFF
--- a/inc/class-wpsweep.php
+++ b/inc/class-wpsweep.php
@@ -332,22 +332,22 @@ class WPSweep {
 				$count = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(option_id) FROM $wpdb->options WHERE option_name LIKE(%s)", '%\_transient\_%' ) );
 				break;
 			case 'orphan_postmeta':
-				$excluded_meta_keys = $this->get_excluded_meta_keys();
+				$excluded_meta_keys = apply_filters( 'wp_sweep_postmeta_whitelist', array() );
 				$exclude_clause      = $this->get_meta_key_exclude_clause( $excluded_meta_keys );
 				$count               = $wpdb->get_var( "SELECT COUNT(meta_id) FROM $wpdb->postmeta WHERE post_id NOT IN (SELECT ID FROM $wpdb->posts) $exclude_clause" );
 				break;
 			case 'orphan_commentmeta':
-				$excluded_meta_keys = $this->get_excluded_meta_keys();
+				$excluded_meta_keys = apply_filters( 'wp_sweep_commentmeta_whitelist', array() );
 				$exclude_clause      = $this->get_meta_key_exclude_clause( $excluded_meta_keys );
 				$count               = $wpdb->get_var( "SELECT COUNT(meta_id) FROM $wpdb->commentmeta WHERE comment_id NOT IN (SELECT comment_ID FROM $wpdb->comments) $exclude_clause" );
 				break;
 			case 'orphan_usermeta':
-				$excluded_meta_keys = $this->get_excluded_meta_keys();
-				$exclude_clause      = $this->get_meta_key_exclude_clause( $excluded_meta_keys, 'umeta_id' );
+				$excluded_meta_keys = apply_filters( 'wp_sweep_usermeta_whitelist', array() );
+				$exclude_clause      = $this->get_meta_key_exclude_clause( $excluded_meta_keys );
 				$count               = $wpdb->get_var( "SELECT COUNT(umeta_id) FROM $wpdb->usermeta WHERE user_id NOT IN (SELECT ID FROM $wpdb->users) $exclude_clause" );
 				break;
 			case 'orphan_termmeta':
-				$excluded_meta_keys = $this->get_excluded_meta_keys();
+				$excluded_meta_keys = apply_filters( 'wp_sweep_termmeta_whitelist', array() );
 				$exclude_clause      = $this->get_meta_key_exclude_clause( $excluded_meta_keys );
 				$count               = $wpdb->get_var( "SELECT COUNT(meta_id) FROM $wpdb->termmeta WHERE term_id NOT IN (SELECT term_id FROM $wpdb->terms) $exclude_clause" );
 				break;
@@ -430,22 +430,22 @@ class WPSweep {
 				$details = $wpdb->get_col( $wpdb->prepare( "SELECT option_name FROM $wpdb->options WHERE option_name LIKE(%s) LIMIT %d", '%\_transient\_%', $this->limit_details ) );
 				break;
 			case 'orphan_postmeta':
-				$excluded_meta_keys = $this->get_excluded_meta_keys();
+				$excluded_meta_keys = apply_filters( 'wp_sweep_postmeta_whitelist', array() );
 				$exclude_clause      = $this->get_meta_key_exclude_clause( $excluded_meta_keys );
 				$details             = $wpdb->get_col( $wpdb->prepare( "SELECT meta_key FROM $wpdb->postmeta WHERE post_id NOT IN (SELECT ID FROM $wpdb->posts) $exclude_clause LIMIT %d", $this->limit_details ) );
 				break;
 			case 'orphan_commentmeta':
-				$excluded_meta_keys = $this->get_excluded_meta_keys();
+				$excluded_meta_keys = apply_filters( 'wp_sweep_commentmeta_whitelist', array() );
 				$exclude_clause      = $this->get_meta_key_exclude_clause( $excluded_meta_keys );
 				$details             = $wpdb->get_col( $wpdb->prepare( "SELECT meta_key FROM $wpdb->commentmeta WHERE comment_id NOT IN (SELECT comment_ID FROM $wpdb->comments) $exclude_clause LIMIT %d", $this->limit_details ) );
 				break;
 			case 'orphan_usermeta':
-				$excluded_meta_keys = $this->get_excluded_meta_keys();
+				$excluded_meta_keys = apply_filters( 'wp_sweep_usermeta_whitelist', array() );
 				$exclude_clause      = $this->get_meta_key_exclude_clause( $excluded_meta_keys );
 				$details             = $wpdb->get_col( $wpdb->prepare( "SELECT meta_key FROM $wpdb->usermeta WHERE user_id NOT IN (SELECT ID FROM $wpdb->users) $exclude_clause LIMIT %d", $this->limit_details ) );
 				break;
 			case 'orphan_termmeta':
-				$excluded_meta_keys = $this->get_excluded_meta_keys();
+				$excluded_meta_keys = apply_filters( 'wp_sweep_termmeta_whitelist', array() );
 				$exclude_clause      = $this->get_meta_key_exclude_clause( $excluded_meta_keys );
 				$details             = $wpdb->get_col( $wpdb->prepare( "SELECT meta_key FROM $wpdb->termmeta WHERE term_id NOT IN (SELECT term_id FROM $wpdb->terms) $exclude_clause LIMIT %d", $this->limit_details ) );
 				break;
@@ -600,7 +600,7 @@ class WPSweep {
 				}
 				break;
 			case 'orphan_postmeta':
-				$excluded_meta_keys = $this->get_excluded_meta_keys();
+				$excluded_meta_keys = apply_filters( 'wp_sweep_postmeta_whitelist', array() );
 				$exclude_clause      = $this->get_meta_key_exclude_clause( $excluded_meta_keys );
 				$query               = $wpdb->get_results( "SELECT post_id, meta_key FROM $wpdb->postmeta WHERE post_id NOT IN (SELECT ID FROM $wpdb->posts) $exclude_clause" );
 				if ( $query ) {
@@ -618,7 +618,7 @@ class WPSweep {
 				}
 				break;
 			case 'orphan_commentmeta':
-				$excluded_meta_keys = $this->get_excluded_meta_keys();
+				$excluded_meta_keys = apply_filters( 'wp_sweep_commentmeta_whitelist', array() );
 				$exclude_clause      = $this->get_meta_key_exclude_clause( $excluded_meta_keys );
 				$query               = $wpdb->get_results( "SELECT comment_id, meta_key FROM $wpdb->commentmeta WHERE comment_id NOT IN (SELECT comment_ID FROM $wpdb->comments) $exclude_clause" );
 				if ( $query ) {
@@ -636,7 +636,7 @@ class WPSweep {
 				}
 				break;
 			case 'orphan_usermeta':
-				$excluded_meta_keys = $this->get_excluded_meta_keys();
+				$excluded_meta_keys = apply_filters( 'wp_sweep_usermeta_whitelist', array() );
 				$exclude_clause      = $this->get_meta_key_exclude_clause( $excluded_meta_keys );
 				$query               = $wpdb->get_results( "SELECT user_id, meta_key FROM $wpdb->usermeta WHERE user_id NOT IN (SELECT ID FROM $wpdb->users) $exclude_clause" );
 				if ( $query ) {
@@ -654,7 +654,7 @@ class WPSweep {
 				}
 				break;
 			case 'orphan_termmeta':
-				$excluded_meta_keys = $this->get_excluded_meta_keys();
+				$excluded_meta_keys = apply_filters( 'wp_sweep_termmeta_whitelist', array() );
 				$exclude_clause      = $this->get_meta_key_exclude_clause( $excluded_meta_keys );
 				$query               = $wpdb->get_results( "SELECT term_id, meta_key FROM $wpdb->termmeta WHERE term_id NOT IN (SELECT term_id FROM $wpdb->terms) $exclude_clause" );
 				if ( $query ) {
@@ -878,52 +878,6 @@ class WPSweep {
 	}
 
 	/**
-	 * Get excluded meta keys
-	 *
-	 * @since 1.0.9
-	 *
-	 * @access private
-	 * @return array Excluded meta keys that should not be deleted when orphaned
-	 */
-	private function get_excluded_meta_keys() {
-		$excluded_keys = array(
-			// WordPress core post meta.
-			'_wp_page_template',
-			'_wp_trash_meta_*',
-			'_wp_desired_post_slug',
-			'_wp_attachment_metadata',
-			'_wp_attachment_image_alt',
-			'_thumbnail_id',
-			'_edit_lock',
-			'_edit_last',
-			// WordPress core user meta.
-			'session_tokens',
-			'capabilities',
-			'user-settings',
-			'user-settings-time',
-			'dismissed_wp_pointers',
-			'show_welcome_panel',
-			// WordPress core comment meta.
-			'akismet_*',
-			// Plugin meta prefixes (common plugins).
-			'_acf_*',
-			'_field_*',
-			'_group_*',
-			'woocommerce_*',
-			'_wccs_*',
-			'_jet_*',
-			'_elementor_*',
-			'_beaver_*',
-			'_divi_*',
-			'_yoast_*',
-			'rank_math_*',
-			'mb_*',
-		);
-
-		return apply_filters( 'wp_sweep_excluded_meta_keys', $excluded_keys );
-	}
-
-	/**
 	 * Build SQL WHERE clause to exclude whitelisted meta keys
 	 *
 	 * @since 1.0.9
@@ -1031,3 +985,4 @@ class WPSweep {
 	private function plugin_deactivated() {
 	}
 }
+

--- a/inc/class-wpsweep.php
+++ b/inc/class-wpsweep.php
@@ -332,16 +332,24 @@ class WPSweep {
 				$count = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(option_id) FROM $wpdb->options WHERE option_name LIKE(%s)", '%\_transient\_%' ) );
 				break;
 			case 'orphan_postmeta':
-				$count = $wpdb->get_var( "SELECT COUNT(meta_id) FROM $wpdb->postmeta WHERE post_id NOT IN (SELECT ID FROM $wpdb->posts)" );
+				$excluded_meta_keys = $this->get_excluded_meta_keys();
+				$exclude_clause      = $this->get_meta_key_exclude_clause( $excluded_meta_keys );
+				$count               = $wpdb->get_var( "SELECT COUNT(meta_id) FROM $wpdb->postmeta WHERE post_id NOT IN (SELECT ID FROM $wpdb->posts) $exclude_clause" );
 				break;
 			case 'orphan_commentmeta':
-				$count = $wpdb->get_var( "SELECT COUNT(meta_id) FROM $wpdb->commentmeta WHERE comment_id NOT IN (SELECT comment_ID FROM $wpdb->comments)" );
+				$excluded_meta_keys = $this->get_excluded_meta_keys();
+				$exclude_clause      = $this->get_meta_key_exclude_clause( $excluded_meta_keys );
+				$count               = $wpdb->get_var( "SELECT COUNT(meta_id) FROM $wpdb->commentmeta WHERE comment_id NOT IN (SELECT comment_ID FROM $wpdb->comments) $exclude_clause" );
 				break;
 			case 'orphan_usermeta':
-				$count = $wpdb->get_var( "SELECT COUNT(umeta_id) FROM $wpdb->usermeta WHERE user_id NOT IN (SELECT ID FROM $wpdb->users)" );
+				$excluded_meta_keys = $this->get_excluded_meta_keys();
+				$exclude_clause      = $this->get_meta_key_exclude_clause( $excluded_meta_keys, 'umeta_id' );
+				$count               = $wpdb->get_var( "SELECT COUNT(umeta_id) FROM $wpdb->usermeta WHERE user_id NOT IN (SELECT ID FROM $wpdb->users) $exclude_clause" );
 				break;
 			case 'orphan_termmeta':
-				$count = $wpdb->get_var( "SELECT COUNT(meta_id) FROM $wpdb->termmeta WHERE term_id NOT IN (SELECT term_id FROM $wpdb->terms)" );
+				$excluded_meta_keys = $this->get_excluded_meta_keys();
+				$exclude_clause      = $this->get_meta_key_exclude_clause( $excluded_meta_keys );
+				$count               = $wpdb->get_var( "SELECT COUNT(meta_id) FROM $wpdb->termmeta WHERE term_id NOT IN (SELECT term_id FROM $wpdb->terms) $exclude_clause" );
 				break;
 			case 'orphan_term_relationships':
 				$orphan_term_relationships_sql = implode( "','", array_map( 'esc_sql', $this->get_excluded_taxonomies() ) );
@@ -422,16 +430,24 @@ class WPSweep {
 				$details = $wpdb->get_col( $wpdb->prepare( "SELECT option_name FROM $wpdb->options WHERE option_name LIKE(%s) LIMIT %d", '%\_transient\_%', $this->limit_details ) );
 				break;
 			case 'orphan_postmeta':
-				$details = $wpdb->get_col( $wpdb->prepare( "SELECT meta_key FROM $wpdb->postmeta WHERE post_id NOT IN (SELECT ID FROM $wpdb->posts) LIMIT %d", $this->limit_details ) );
+				$excluded_meta_keys = $this->get_excluded_meta_keys();
+				$exclude_clause      = $this->get_meta_key_exclude_clause( $excluded_meta_keys );
+				$details             = $wpdb->get_col( $wpdb->prepare( "SELECT meta_key FROM $wpdb->postmeta WHERE post_id NOT IN (SELECT ID FROM $wpdb->posts) $exclude_clause LIMIT %d", $this->limit_details ) );
 				break;
 			case 'orphan_commentmeta':
-				$details = $wpdb->get_col( $wpdb->prepare( "SELECT meta_key FROM $wpdb->commentmeta WHERE comment_id NOT IN (SELECT comment_ID FROM $wpdb->comments) LIMIT %d", $this->limit_details ) );
+				$excluded_meta_keys = $this->get_excluded_meta_keys();
+				$exclude_clause      = $this->get_meta_key_exclude_clause( $excluded_meta_keys );
+				$details             = $wpdb->get_col( $wpdb->prepare( "SELECT meta_key FROM $wpdb->commentmeta WHERE comment_id NOT IN (SELECT comment_ID FROM $wpdb->comments) $exclude_clause LIMIT %d", $this->limit_details ) );
 				break;
 			case 'orphan_usermeta':
-				$details = $wpdb->get_col( $wpdb->prepare( "SELECT meta_key FROM $wpdb->usermeta WHERE user_id NOT IN (SELECT ID FROM $wpdb->users) LIMIT %d", $this->limit_details ) );
+				$excluded_meta_keys = $this->get_excluded_meta_keys();
+				$exclude_clause      = $this->get_meta_key_exclude_clause( $excluded_meta_keys );
+				$details             = $wpdb->get_col( $wpdb->prepare( "SELECT meta_key FROM $wpdb->usermeta WHERE user_id NOT IN (SELECT ID FROM $wpdb->users) $exclude_clause LIMIT %d", $this->limit_details ) );
 				break;
 			case 'orphan_termmeta':
-				$details = $wpdb->get_col( $wpdb->prepare( "SELECT meta_key FROM $wpdb->termmeta WHERE term_id NOT IN (SELECT term_id FROM $wpdb->terms) LIMIT %d", $this->limit_details ) );
+				$excluded_meta_keys = $this->get_excluded_meta_keys();
+				$exclude_clause      = $this->get_meta_key_exclude_clause( $excluded_meta_keys );
+				$details             = $wpdb->get_col( $wpdb->prepare( "SELECT meta_key FROM $wpdb->termmeta WHERE term_id NOT IN (SELECT term_id FROM $wpdb->terms) $exclude_clause LIMIT %d", $this->limit_details ) );
 				break;
 			case 'orphan_term_relationships':
 				$orphan_term_relationships_sql = implode( "','", array_map( 'esc_sql', $this->get_excluded_taxonomies() ) );
@@ -584,7 +600,9 @@ class WPSweep {
 				}
 				break;
 			case 'orphan_postmeta':
-				$query = $wpdb->get_results( "SELECT post_id, meta_key FROM $wpdb->postmeta WHERE post_id NOT IN (SELECT ID FROM $wpdb->posts)" );
+				$excluded_meta_keys = $this->get_excluded_meta_keys();
+				$exclude_clause      = $this->get_meta_key_exclude_clause( $excluded_meta_keys );
+				$query               = $wpdb->get_results( "SELECT post_id, meta_key FROM $wpdb->postmeta WHERE post_id NOT IN (SELECT ID FROM $wpdb->posts) $exclude_clause" );
 				if ( $query ) {
 					foreach ( $query as $meta ) {
 						$post_id = (int) $meta->post_id;
@@ -600,7 +618,9 @@ class WPSweep {
 				}
 				break;
 			case 'orphan_commentmeta':
-				$query = $wpdb->get_results( "SELECT comment_id, meta_key FROM $wpdb->commentmeta WHERE comment_id NOT IN (SELECT comment_ID FROM $wpdb->comments)" );
+				$excluded_meta_keys = $this->get_excluded_meta_keys();
+				$exclude_clause      = $this->get_meta_key_exclude_clause( $excluded_meta_keys );
+				$query               = $wpdb->get_results( "SELECT comment_id, meta_key FROM $wpdb->commentmeta WHERE comment_id NOT IN (SELECT comment_ID FROM $wpdb->comments) $exclude_clause" );
 				if ( $query ) {
 					foreach ( $query as $meta ) {
 						$comment_id = (int) $meta->comment_id;
@@ -616,7 +636,9 @@ class WPSweep {
 				}
 				break;
 			case 'orphan_usermeta':
-				$query = $wpdb->get_results( "SELECT user_id, meta_key FROM $wpdb->usermeta WHERE user_id NOT IN (SELECT ID FROM $wpdb->users)" );
+				$excluded_meta_keys = $this->get_excluded_meta_keys();
+				$exclude_clause      = $this->get_meta_key_exclude_clause( $excluded_meta_keys );
+				$query               = $wpdb->get_results( "SELECT user_id, meta_key FROM $wpdb->usermeta WHERE user_id NOT IN (SELECT ID FROM $wpdb->users) $exclude_clause" );
 				if ( $query ) {
 					foreach ( $query as $meta ) {
 						$user_id = (int) $meta->user_id;
@@ -632,7 +654,9 @@ class WPSweep {
 				}
 				break;
 			case 'orphan_termmeta':
-				$query = $wpdb->get_results( "SELECT term_id, meta_key FROM $wpdb->termmeta WHERE term_id NOT IN (SELECT term_id FROM $wpdb->terms)" );
+				$excluded_meta_keys = $this->get_excluded_meta_keys();
+				$exclude_clause      = $this->get_meta_key_exclude_clause( $excluded_meta_keys );
+				$query               = $wpdb->get_results( "SELECT term_id, meta_key FROM $wpdb->termmeta WHERE term_id NOT IN (SELECT term_id FROM $wpdb->terms) $exclude_clause" );
 				if ( $query ) {
 					foreach ( $query as $meta ) {
 						$term_id = (int) $meta->term_id;
@@ -851,6 +875,88 @@ class WPSweep {
 	private function get_parent_termids() {
 		global $wpdb;
 		return $wpdb->get_col( $wpdb->prepare( "SELECT tt.parent FROM $wpdb->terms AS t INNER JOIN $wpdb->term_taxonomy AS tt ON t.term_id = tt.term_id WHERE tt.parent > %d", 0 ) );
+	}
+
+	/**
+	 * Get excluded meta keys
+	 *
+	 * @since 1.0.9
+	 *
+	 * @access private
+	 * @return array Excluded meta keys that should not be deleted when orphaned
+	 */
+	private function get_excluded_meta_keys() {
+		$excluded_keys = array(
+			// WordPress core post meta.
+			'_wp_page_template',
+			'_wp_trash_meta_*',
+			'_wp_desired_post_slug',
+			'_wp_attachment_metadata',
+			'_wp_attachment_image_alt',
+			'_thumbnail_id',
+			'_edit_lock',
+			'_edit_last',
+			// WordPress core user meta.
+			'session_tokens',
+			'capabilities',
+			'user-settings',
+			'user-settings-time',
+			'dismissed_wp_pointers',
+			'show_welcome_panel',
+			// WordPress core comment meta.
+			'akismet_*',
+			// Plugin meta prefixes (common plugins).
+			'_acf_*',
+			'_field_*',
+			'_group_*',
+			'woocommerce_*',
+			'_wccs_*',
+			'_jet_*',
+			'_elementor_*',
+			'_beaver_*',
+			'_divi_*',
+			'_yoast_*',
+			'rank_math_*',
+			'mb_*',
+		);
+
+		return apply_filters( 'wp_sweep_excluded_meta_keys', $excluded_keys );
+	}
+
+	/**
+	 * Build SQL WHERE clause to exclude whitelisted meta keys
+	 *
+	 * @since 1.0.9
+	 *
+	 * @access private
+	 * @param array  $excluded_keys List of excluded meta key patterns.
+	 * @param string $meta_key_column Name of the meta_key column (default: 'meta_key').
+	 * @return string SQL WHERE clause fragment
+	 */
+	private function get_meta_key_exclude_clause( $excluded_keys, $meta_key_column = 'meta_key' ) {
+		global $wpdb;
+
+		if ( empty( $excluded_keys ) ) {
+			return '';
+		}
+
+		$conditions = array();
+		foreach ( $excluded_keys as $key ) {
+			if ( strpos( $key, '*' ) !== false ) {
+				// Handle wildcard patterns using LIKE.
+				$pattern = str_replace( '*', '%', $key );
+				$conditions[] = $wpdb->prepare( "$meta_key_column NOT LIKE %s", $pattern );
+			} else {
+				// Exact match.
+				$conditions[] = $wpdb->prepare( "$meta_key_column != %s", $key );
+			}
+		}
+
+		if ( empty( $conditions ) ) {
+			return '';
+		}
+
+		return 'AND ' . implode( ' AND ', $conditions );
 	}
 
 	/**


### PR DESCRIPTION
**TL;DR:** The original approach hardcoded plugin-specific meta keys into the plugin itself — lesterchan was right to push back on that. This rework removes all hardcoded keys and replaces the single `wp_sweep_excluded_meta_keys` filter with four separate empty-default per-type filters. Plugins opt in to protect their own keys; wp-sweep protects nothing by default. While working through the implementation, AI spotted a pre-existing bug where the usermeta sweep was passing the primary key column name (`umeta_id`) to the exclude clause instead of `meta_key`, causing WHERE conditions to match row IDs instead of key names — that's fixed here too.

---

## Summary

Replaces the single `wp_sweep_excluded_meta_keys` filter (which bundled hardcoded plugin-specific keys) with four separate per-type filters, each with an empty array default:

- `wp_sweep_postmeta_whitelist`
- `wp_sweep_commentmeta_whitelist`
- `wp_sweep_usermeta_whitelist`
- `wp_sweep_termmeta_whitelist`

Removes the `get_excluded_meta_keys()` private method and all hardcoded plugin meta key patterns from the plugin. Plugins that need to protect their own keys can hook into the appropriate filter.

Also fixes a pre-existing bug in the usermeta sweep: `get_meta_key_exclude_clause()` was being called with `'umeta_id'` as the `$meta_key_column` argument, causing the WHERE clause to match against row IDs (`umeta_id`) instead of meta key names (`meta_key`). The redundant argument is removed.

## Problem

The previous approach included a hardcoded list of meta keys from WP core, ACF, WooCommerce, Elementor, Yoast, and other plugins. This meant:
- wp-sweep was maintaining a list that belongs to each respective plugin
- Any plugin not on the list got no protection
- The list would require ongoing maintenance as plugins change their key patterns

## Solution

Empty-default per-type filters give plugin authors control over their own keys without wp-sweep needing to know about them. A plugin that wants to protect `my_plugin_*` keys hooks `wp_sweep_postmeta_whitelist` and returns the patterns it cares about.

(full disclosure: AI helped me identify the issue and verify my work)